### PR TITLE
Force use of test_enable option use the bypass over cr.commit

### DIFF
--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -38,6 +38,9 @@ except ImportError:  # Odoo >= 10.0
 def pytest_cmdline_main(config):
     if os.environ.get('OPENERP_SERVER'):
         odoo.tools.config.parse_config([])
+        # force the use of test_enable
+        if not odoo.tools.config['test_enable']:
+            odoo.tools.config['test_enable'] = True
         dbname = odoo.tools.config['db_name']
         if not dbname:
             raise Exception(


### PR DESCRIPTION
In some tests we rely on this config to know if we are in a test context or not.