### PR TITLE
Add --odoo-database and --odoo-log-level options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,15 @@ install via::
 
 usage::
 
+   pytest -s --odoo-database=test --odoo-log-level=debug_sql
+
+The custom options are:
+
+* ``--odoo-database``: name of the database to test
+* ``--odoo-log-level``: log level as expected by odoo. As time of writing: info, debug_rpc, warn, test, critical, debug_sql, error, debug, debug_rpc_answer. The default is critical to have a clean output.
+
+Alternatively, you can use the ``OPENERP_SERVER`` environment variable using an odoo configuration file, containing at least the ``database`` option with the name of the database to test::
+
    export OPENERP_SERVER=/path/to/odoo/config.cfg
    pytest ...
 
-The path of the Odoo configuration file must be set in the ``OPENERP_SERVER``
-environment variable. The configuration file must contain the name of the
-database on which the tests are run.


### PR DESCRIPTION
Propagate the options to Odoo. We don't need anymore to mess with
OPENERP_SERVER and configuration files!

And bonus, customization of the log-level is possible, clean by default,
but possibility to show sql queries or debug logs when needed. Hooray!