### PR TITLE
Fix incompatibility with pytest 3.7

### DIFF
--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -100,7 +100,10 @@ def enable_odoo_test_flag():
 
 
 def pytest_pycollect_makemodule(path, parent):
-    return OdooTestModule(path, parent)
+    if path.basename == "__init__.py":
+       return pytest.Package(path, parent)
+    else:
+       return OdooTestModule(path, parent)
 
 
 # Original code of xmo-odoo:


### PR DESCRIPTION
After I upgraded pytest to version 3.7, it cannot find any test in my project.

I look into pytest source code. I find out that the problem is the function `pytest_pycollect_makemodule` always return `OdooTestModule` object but in the original pytest source code it will check the path first. If the path is `__init__.py` it will return `Package` object.

 