### PR TITLE
Prevent duplicate Odoo module loading.

### DIFF
--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -101,9 +101,9 @@ def enable_odoo_test_flag():
 
 def pytest_pycollect_makemodule(path, parent):
     if path.basename == "__init__.py":
-       return pytest.Package(path, parent)
+        return OdooTestPackage(path, parent)
     else:
-       return OdooTestModule(path, parent)
+        return OdooTestModule(path, parent)
 
 
 # Original code of xmo-odoo:
@@ -169,3 +169,7 @@ class OdooTestModule(_pytest.python.Module):
             )
         self.config.pluginmanager.consider_module(mod)
         return mod
+
+
+class OdooTestPackage(_pytest.python.Package, OdooTestModule):
+    pass

--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -99,13 +99,6 @@ def enable_odoo_test_flag():
     odoo.tools.config['test_enable'] = False
 
 
-def pytest_pycollect_makemodule(path, parent):
-    if path.basename == "__init__.py":
-        return OdooTestPackage(path, parent)
-    else:
-        return OdooTestModule(path, parent)
-
-
 # Original code of xmo-odoo:
 # https://github.com/odoo-dev/odoo/commit/95a131b7f4eebc6e2c623f936283153d62f9e70f
 class OdooTestModule(_pytest.python.Module):
@@ -172,4 +165,20 @@ class OdooTestModule(_pytest.python.Module):
 
 
 class OdooTestPackage(_pytest.python.Package, OdooTestModule):
+    """Package with odoo module lookup.
+
+    Any python module inside the package will be imported with
+    the prefix `odoo.addons`.
+
+    This class is used to prevent loading odoo modules in duplicate,
+    which happens if a module is loaded with and without the prefix.
+    """
+
     pass
+
+
+def pytest_pycollect_makemodule(path, parent):
+    if path.basename == "__init__.py":
+        return OdooTestPackage(path, parent)
+    else:
+        return OdooTestModule(path, parent)


### PR DESCRIPTION
Prior to this commit, any odoo module was loaded in duplicate.

For example, with the module report_aeroo:

First, the module was loaded as odoo.addons.report_aeroo,
then, it was loaded a second time as report_aeroo (without odoo.addons).

Therefore, any model inside the module was declared 2 times.