### PR TITLE
Fix module name when custom modules are under default odoo addons folder

### DIFF
--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -127,6 +127,9 @@ class OdooTestModule(_pytest.python.Module):
                     and modname != odoo_namespace + '.addons'
                     and modname != odoo_namespace):
                 modname = odoo_namespace + '.addons.' + modname
+            # fix module name when custom modules are installed directly under default odoo ./addons folder
+            if modname.startswith(odoo_namespace + '.addons.addons.'):
+                modname = modname.replace(odoo_namespace + '.addons.addons.', odoo_namespace + '.addons.')
 
             __import__(modname)
             mod = sys.modules[modname]


### PR DESCRIPTION
Hi,
We have custom modules installed under ./addons folder together with default odoo modules.
This fixes the invalid module path with duplicated "addons.addons": Invalid name "openerp.addons.addons.xyz_mod" becomes "openerp.addons.xyz_mod"
Thanks
R.
