### PR TITLE
Added configuration file as a command line option

### DIFF
--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -43,6 +43,7 @@ def pytest_addoption(parser):
 def pytest_cmdline_main(config):
 
     if (config.getoption('--odoo-database')
+            or config.getoption('--odoo-config')
             or os.environ.get('OPENERP_SERVER')
             or os.environ.get('ODOO_RC')):
         options = []

--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -30,6 +30,9 @@ def pytest_addoption(parser):
     parser.addoption("--odoo-database",
                      action="store",
                      help="Name of the Odoo database to test")
+    parser.addoption("--odoo-config",
+                     action="store",
+                     help="Path of the Odoo configuration file")
     parser.addoption("--odoo-log-level",
                      action="store",
                      default='critical',
@@ -45,7 +48,7 @@ def pytest_cmdline_main(config):
         options = []
         # Replace --odoo-<something> by --<something> and prepare the argument
         # to propagate to odoo.
-        for option in ['--odoo-database', '--odoo-log-level']:
+        for option in ['--odoo-database', '--odoo-log-level', '--odoo-config']:
             value = config.getoption(option)
             if value:
                 odoo_arg = '--%s' % option[7:]


### PR DESCRIPTION
This allows one to explicitly set the Odoo configuration file rather then pull it from environmental variables (Useful on Windows platforms where the IDE's can't set the variable properly for some reason)