### PR TITLE
Drop openerp namespace support

### DIFF
--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -17,13 +17,7 @@ import pytest
 
 from pathlib import Path
 
-try:
-    import openerp
-    odoo = openerp
-    odoo_namespace = 'openerp'
-except ImportError:  # Odoo >= 10.0
-    import odoo  # noqa
-    odoo_namespace = 'odoo'
+import odoo
 
 
 def pytest_addoption(parser):
@@ -125,17 +119,12 @@ class OdooTestModule(_pytest.python.Module):
             if names[-1] == "__init__":
                 names.pop()
             modname = ".".join(names)
-            # modules installed with pip for odoo<=9 are into the
-            # odoo_addons namespace. Makes module part of the odoo namespace
-            if modname.startswith('odoo_addons'):
-                modname = odoo_namespace + '.addons.' + modname.replace(
-                    'odoo_addons.', '')
-            # for modules in openerp/addons, since there is a __init__ the
+            # for modules in odoo/addons, since there is a __init__ the
             # module name is already fully qualified (maybe?)
-            if (not modname.startswith(odoo_namespace + '.addons.')
-                    and modname != odoo_namespace + '.addons'
-                    and modname != odoo_namespace):
-                modname = odoo_namespace + '.addons.' + modname
+            if (not modname.startswith('odoo.addons.')
+                    and modname != 'odoo.addons'
+                    and modname != 'odoo'):
+                modname = 'odoo.addons.' + modname
 
             __import__(modname)
             mod = sys.modules[modname]


### PR DESCRIPTION
Since we dropped python 2 support, we can drop Odoo < 11 support too.