### PR TITLE
Require pytest>=7.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     setup_requires=[
         'setuptools_scm',
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'pytest>=7.0.0',
+        'pytest>=7.2.0',
     ],
     setup_requires=[
         'setuptools_scm',


### PR DESCRIPTION
This follows #53.

@simahawk it'd be nice if you could cut a release with this to avoid confusion.

Longer term, we should try to remove the dependency on pytest internals.
