### PR TITLE
feat: consider environment variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Alternatively, you can use environment variables, like the Odoo Docker image:
 
 These only work in addition to ``--odoo-database``.
 
-For backwards compatibility reasons, you can use the ``OPENERP_SERVER`` environment variable using an odoo configuration file, containing at least the ``database`` option with the name of the database to test::
+You can use the ``ODOO_RC`` environment variable using an odoo configuration file, containing at least the ``database`` option with the name of the database to test::
 
    export OPENERP_SERVER=/path/to/odoo/config.cfg
    pytest ...

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,16 @@ The custom options are:
 * ``--odoo-log-level``: log level as expected by odoo. As time of writing: info, debug_rpc, warn, test, critical, debug_sql, error, debug, debug_rpc_answer. The default is critical to have a clean output.
 * ``--odoo-config``: path of the odoo.cfg file to use.
 
-Alternatively, you can use the ``OPENERP_SERVER`` environment variable using an odoo configuration file, containing at least the ``database`` option with the name of the database to test::
+Alternatively, you can use environment variables, like the Odoo Docker image:
+
+* ``HOST``: hostname of the database server
+* ``PORT``: port of the database server
+* ``USER``: username to access the database
+* ``PASSWORD``: password to access the database
+
+These only work in addition to ``--odoo-database``.
+
+For backwards compatibility reasons, you can use the ``OPENERP_SERVER`` environment variable using an odoo configuration file, containing at least the ``database`` option with the name of the database to test::
 
    export OPENERP_SERVER=/path/to/odoo/config.cfg
    pytest ...

--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -54,6 +54,12 @@ def pytest_cmdline_main(config):
                 odoo_arg = '--%s' % option[7:]
                 options.append('%s=%s' % (odoo_arg, value))
 
+        # Check the environment variables supported by the Odoo Docker image
+        # ref: https://hub.docker.com/_/odoo
+        for arg in ['HOST', 'PORT', 'USER', 'PASSWORD']:
+            if os.environ.get(arg):
+                options.append('--db_%s=%s' % (arg.lower(), os.environ.get(arg)))
+
         odoo.tools.config.parse_config(options)
 
         if not odoo.tools.config['db_name']:


### PR DESCRIPTION
When this pytest plugin is used within the Odoo Docker image, we have to take the database configuration from the environment variables. On normal Docker image execution this configuration is done by the `entrypoint.sh`.

This also addresses issue https://github.com/camptocamp/pytest-odoo/issues/39