### PR TITLE
Update pytest dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'pytest>=7.2.0',
+        'pytest>=7.2.0,<8.0.0',
     ],
     setup_requires=[
         'setuptools_scm',


### PR DESCRIPTION
pytest_odoo is not compatible with pytest>=8.0.0

The error I got with pytest==8.0.0 + Odoo v17:
```
odoo@3c3044bef712:/opt/lib/avoinsystems-addons-enterprise$ pytest --odoo-database=test_account_bank_statement_import_camt_fi --odoo-dev=xml account_bank_statement_import_camt_fi
================================================================================================================= test session starts =================================================================================================================
platform linux -- Python 3.11.7, pytest-8.0.0, pluggy-1.4.0
rootdir: /opt/lib/avoinsystems-addons-enterprise
plugins: odoo-0.7.2.dev24+gb52b119
collected 0 items / 1 error                                                                                                                                                                                                                           

======================================================================================================================= ERRORS ========================================================================================================================
__________________________________________________________________________________ ERROR collecting account_bank_statement_import_camt_fi/tests/test_camt_import.py ___________________________________________________________________________________
/usr/local/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1204: in _gcd_import
    ???
<frozen importlib._bootstrap>:1176: in _find_and_load
    ???
<frozen importlib._bootstrap>:1126: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:241: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1204: in _gcd_import
    ???
<frozen importlib._bootstrap>:1176: in _find_and_load
    ???
<frozen importlib._bootstrap>:1126: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:241: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1204: in _gcd_import
    ???
<frozen importlib._bootstrap>:1176: in _find_and_load
    ???
<frozen importlib._bootstrap>:1147: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:690: in _load_unlocked
    ???
<frozen importlib._bootstrap_external>:940: in exec_module
    ???
<frozen importlib._bootstrap>:241: in _call_with_frames_removed
    ???
account_bank_statement_import_camt_fi/__init__.py:1: in <module>
    from . import models
account_bank_statement_import_camt_fi/models/__init__.py:1: in <module>
    from . import account_bank_statement_line
account_bank_statement_import_camt_fi/models/account_bank_statement_line.py:4: in <module>
    class AccountBankStatementLine(models.Model):
/opt/odoo/odoo/models.py:208: in __new__
    assert module.startswith('odoo.addons.'), \
E   AssertionError: Invalid import of account_bank_statement_import_camt_fi.models.account_bank_statement_line.AccountBankStatementLine, it should start with 'odoo.addons'.
=============================================================================================================== short test summary info ===============================================================================================================
ERROR account_bank_statement_import_camt_fi/tests/test_camt_import.py - AssertionError: Invalid import of account_bank_statement_import_camt_fi.models.account_bank_statement_line.AccountBankStatementLine, it should start with 'odoo.addons'.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================================================================================================== 1 error in 0.32s ===================================================================================================================
```