### PR TITLE
Support pytest > 8.0:

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,13 @@ install via::
 
     pip install pytest-odoo
 
+Since pytest version >= 8.1 configure pytest to use `odoo.addons` namespace
+using `consider_namespace_packages <https://docs.pytest.org/en/stable/
+reference/reference.html#confval-consider_namespace_packages>`_  option::
+
+   [tool.pytest.ini_options]
+   consider_namespace_packages = true
+
 usage::
 
    pytest -s --odoo-database=test --odoo-log-level=debug_sql [--odoo-http]

--- a/README.rst
+++ b/README.rst
@@ -25,13 +25,6 @@ install via::
 
     pip install pytest-odoo
 
-Since pytest version >= 8.1 configure pytest to use `odoo.addons` namespace
-using `consider_namespace_packages <https://docs.pytest.org/en/stable/
-reference/reference.html#confval-consider_namespace_packages>`_  option::
-
-   [tool.pytest.ini_options]
-   consider_namespace_packages = true
-
 usage::
 
    pytest -s --odoo-database=test --odoo-log-level=debug_sql [--odoo-http]

--- a/README.rst
+++ b/README.rst
@@ -50,9 +50,3 @@ You can use the ``ODOO_RC`` environment variable using an odoo configuration fil
 
    export ODOO_RC=/path/to/odoo/config.cfg
    pytest ...
-
-
-Known issues
-------------
-
-Currently not compatible with pytest >= 8.0.0

--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -43,7 +43,6 @@ def pytest_addoption(parser):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_cmdline_main(config):
-
     if (config.getoption('--odoo-database')
             or config.getoption('--odoo-config')
             or config.getoption('--odoo-dev')
@@ -224,10 +223,12 @@ def _find_manifest_path(collection_path: Path) -> Path:
     """Try to locate an Odoo manifest file in the collection path."""
     # check if collection_path is an addon directory
     path = collection_path
-    level = 0
-    while level < 5  and not (path.parent / "__manifest__.py").is_file():
+    for _ in range(0, 5): 
+        if (path.parent / "__manifest__.py").is_file():
+            break
         path = path.parent
-        level += 1
+    else:
+        return None
     return path.parent / "__manifest__.py"
 
 

--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -20,6 +20,16 @@ import odoo.tests
 import pytest
 from _pytest._code.code import ExceptionInfo
 
+def monkey_patch_odoo_meta_model():
+    originalMetaModel_new = odoo.models.MetaModel.__new__
+
+    def __monkeypatch_new(self, name, bases, attrs):
+        if not attrs.get("__module__", "odoo.addons").startswith("odoo.addons"):
+            attrs["__module__"] = f"odoo.addons.{attrs.get('__module__', '')}" 
+        return originalMetaModel_new(self, name, bases, attrs) 
+
+    odoo.models.MetaModel.__new__ = __monkeypatch_new
+
 
 def pytest_addoption(parser):
     parser.addoption("--odoo-database",
@@ -79,6 +89,7 @@ def pytest_cmdline_main(config):
                 "please provide a database name in the Odoo configuration file"
             )
 
+        monkey_patch_odoo_meta_model()
         odoo.service.server.start(preload=[], stop=True)
         # odoo.service.server.start() modifies the SIGINT signal by its own
         # one which in fact prevents us to stop anthem with Ctrl-c.
@@ -128,95 +139,6 @@ def enable_odoo_test_flag():
     odoo.tools.config['test_enable'] = True
     yield
     odoo.tools.config['test_enable'] = False
-
-
-# Original code of xmo-odoo:
-# https://github.com/odoo-dev/odoo/commit/95a131b7f4eebc6e2c623f936283153d62f9e70f
-class OdooTestModule(_pytest.python.Module):
-    """ Should only be invoked for paths inside Odoo addons
-    """
-
-    def _importtestmodule(self):
-        # copy/paste/modified from original: removed sys.path injection &
-        # added Odoo module prefixing so import within modules is correct
-        try:
-            pypkgpath = self.fspath.pypkgpath()
-            pkgroot = pypkgpath.dirpath()
-            sep = self.fspath.sep
-            names = self.fspath.new(ext="").relto(pkgroot).split(sep)
-            if names[-1] == "__init__":
-                names.pop()
-            modname = ".".join(names)
-            # for modules in odoo/addons, since there is a __init__ the
-            # module name is already fully qualified (maybe?)
-            if (not modname.startswith('odoo.addons.')
-                    and modname != 'odoo.addons'
-                    and modname != 'odoo'):
-                modname = 'odoo.addons.' + modname
-
-            __import__(modname)
-            mod = sys.modules[modname]
-            if self.fspath.basename == "__init__.py":
-                # we don't check anything as we might
-                # we in a namespace package ... too icky to check
-                return mod
-            modfile = mod.__file__
-            if modfile[-4:] in ('.pyc', '.pyo'):
-                modfile = modfile[:-1]
-            elif modfile.endswith('$py.class'):
-                modfile = modfile[:-9] + '.py'
-            if modfile.endswith(os.path.sep + "__init__.py"):
-                if self.fspath.basename != "__init__.py":
-                    modfile = modfile[:-12]
-            try:
-                issame = self.fspath.samefile(modfile)
-            except error.ENOENT:
-                issame = False
-            if not issame:
-                raise self.fspath.ImportMismatchError(modname, modfile, self)
-        except SyntaxError as e:
-            raise self.CollectError(
-                ExceptionInfo.from_current().getrepr(style="short")
-            ) from e
-        except self.fspath.ImportMismatchError:
-            e = sys.exc_info()[1]
-            raise self.CollectError(
-                "import file mismatch:\n"
-                "imported module %r has this __file__ attribute:\n"
-                "  %s\n"
-                "which is not the same as the test file we want to collect:\n"
-                "  %s\n"
-                "HINT: remove __pycache__ / .pyc files and/or use a "
-                "unique basename for your test file modules" % e.args
-            )
-        self.config.pluginmanager.consider_module(mod)
-        return mod
-
-    def __repr__(self):
-        return "<Module %r>" % (getattr(self, "name", None), )
-
-
-class OdooTestPackage(_pytest.python.Package, OdooTestModule):
-    """Package with odoo module lookup.
-
-    Any python module inside the package will be imported with
-    the prefix `odoo.addons`.
-
-    This class is used to prevent loading odoo modules in duplicate,
-    which happens if a module is loaded with and without the prefix.
-    """
-
-    def __repr__(self):
-        return "<Package %r>" % (getattr(self, "name", None), )
-
-
-def pytest_pycollect_makemodule(module_path, path, parent):
-    if not _find_manifest_path(module_path):
-        return None
-    if path.basename == "__init__.py":
-        return OdooTestPackage.from_parent(parent, path=Path(path))
-    else:
-        return OdooTestModule.from_parent(parent, path=Path(path))
 
 
 def _find_manifest_path(collection_path: Path) -> Path:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         # reference/reference.html
         # #confval-consider_namespace_packages>`_ option pytest version 8.1 and
         # above works
-        'pytest>=7.2.0,!=8.0.*',
+        'pytest>=7.2.0',
     ],
     setup_requires=[
         'setuptools_scm',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'pytest>=7.2.0,<8.0.0',
+        'pytest>=7.2.0',
     ],
     setup_requires=[
         'setuptools_scm',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,11 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'pytest>=7.2.0',
+        # using `consider_namespace_packages <https://docs.pytest.org/en/stable/
+        # reference/reference.html
+        # #confval-consider_namespace_packages>`_ option pytest version 8.1 and
+        # above works
+        'pytest>=7.2.0,!=8.0.*',
     ],
     setup_requires=[
         'setuptools_scm',

--- a/tests/test_pytest_odoo.py
+++ b/tests/test_pytest_odoo.py
@@ -1,0 +1,7 @@
+from pytest_odoo import _find_manifest_path
+from pathlib import Path
+
+
+def test_find_manifest_path():
+    
+    assert _find_manifest_path(Path("/some/path")) is None


### PR DESCRIPTION
Since pytest v8 we are receiving more file in _find_manifest_path method that method should not return a non present file in case __manifest__ is not found in 5 parents directory