### PR TITLE
Support pytest > 8.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,3 @@ You can use the ``ODOO_RC`` environment variable using an odoo configuration fil
    export ODOO_RC=/path/to/odoo/config.cfg
    pytest ...
 
-
-Known issues
-------------
-
-Currently not compatible with pytest >= 8.0.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'pytest>=7.2.0,<8.0.0',
+        "pytest>=8"
     ],
     setup_requires=[
         'setuptools_scm',

--- a/tests/test_pytest_odoo.py
+++ b/tests/test_pytest_odoo.py
@@ -1,21 +1,39 @@
-from unittest import TestCase
 import tempfile
 from contextlib import contextmanager
-from pytest_odoo import _find_manifest_path
 from pathlib import Path
+from unittest import TestCase
+
+from _pytest import pathlib as pytest_pathlib
+from pytest_odoo import (
+    _find_manifest_path,
+    monkey_patch_resolve_pkg_root_and_module_name,
+)
+
 
 class TestPytestOdoo(TestCase):
 
     @contextmanager
-    def fake_module(self):
+    def fake_module(self, with_manifest=True,  using_addons_namespace=False):
         directory = tempfile.TemporaryDirectory()
         try:
             module_path = Path(directory.name)
-            manifest_path = module_path / "__manifest__.py"
-            manifest_path.touch()
+            files = []
+            if using_addons_namespace:
+                files.append(module_path / "odoo" / "__init__.py")
+                files.append(module_path / "odoo" / "addons" / "__init__.py")
+                module_path = module_path / "odoo" / "addons" / "my_module"
+                module_path.mkdir(parents=True, exist_ok=True)
+            manifest_path = None
+            if with_manifest:
+                manifest_path = module_path / "__manifest__.py"
+                files.append(manifest_path)
             test_path = module_path / "tests" / "test_module.py"
             test_path.parent.mkdir(parents=True, exist_ok=True)
-            test_path.touch()
+            files.append(test_path)
+            files.append(module_path / "__init__.py")
+            files.append(module_path / "tests" / "__init__.py")
+            for file_path in files:
+                file_path.touch()
             yield (module_path, manifest_path, test_path,)
         finally:
             directory.cleanup()
@@ -37,3 +55,32 @@ class TestPytestOdoo(TestCase):
             test = module_path / "test_something.py"
             test.touch()
             self.assertEqual(_find_manifest_path(test), manifest_path)
+
+    def test_resolve_pkg_root_and_module_name(self):
+        monkey_patch_resolve_pkg_root_and_module_name()
+        with self.fake_module() as (module_path, _, test_path):
+            pkg_root, module_name = pytest_pathlib.resolve_pkg_root_and_module_name(test_path)
+            self.assertEqual(
+                module_name,
+                f"odoo.addons.{module_path.name}.tests.test_module"
+            )
+
+    def test_resolve_pkg_root_and_module_name_not_odoo_module(self):
+        monkey_patch_resolve_pkg_root_and_module_name()
+
+        with self.fake_module(with_manifest=False) as (module_path, _, test_path):
+            pkg_root, module_name = pytest_pathlib.resolve_pkg_root_and_module_name(test_path)
+            self.assertEqual(
+                module_name,
+                f"{module_path.name}.tests.test_module"
+            )
+
+    def test_resolve_pkg_root_and_module_name_namespace_ok(self):
+        monkey_patch_resolve_pkg_root_and_module_name()
+
+        with self.fake_module(with_manifest=True, using_addons_namespace=True) as (module_path, _, test_path):
+            pkg_root, module_name = pytest_pathlib.resolve_pkg_root_and_module_name(test_path)
+            self.assertEqual(
+                module_name,
+                "odoo.addons.my_module.tests.test_module"
+            )


### PR DESCRIPTION
Here monkey patching pytest itself to load test odoo test modules forcing odoo namespacing  

this PR is based on #73 