### PR TITLE
Ensure filestore is shared when ran in a distributed way

### DIFF
--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -141,6 +141,7 @@ def _worker_db_name():
             os.system(f"dropdb {db_name} --if-exists")
             os.system(f"createdb -T {original_db_name} {db_name}")
             odoo.tools.config["db_name"] = db_name
+            odoo.tools.config["dbfilter"] = f"^{db_name}$"
         with _shared_filestore(original_db_name, db_name):
             yield db_name
     finally:
@@ -148,6 +149,7 @@ def _worker_db_name():
             odoo.sql_db.close_db(db_name)
             os.system(f"dropdb {db_name}")
             odoo.tools.config["db_name"] = original_db_name
+            odoo.tools.config["dbfilter"] = f"^{original_db_name}$"
 
     
 @pytest.fixture(scope='session', autouse=True)

--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -7,6 +7,7 @@
 import ast
 import os
 import signal
+import subprocess
 import threading
 from contextlib import contextmanager
 from unittest import mock
@@ -138,8 +139,8 @@ def _worker_db_name():
     try:
         if xdist_worker:
             db_name = f"{original_db_name}-{xdist_worker}"
-            os.system(f"dropdb {db_name} --if-exists")
-            os.system(f"createdb -T {original_db_name} {db_name}")
+            subprocess.run(["dropdb", db_name, "--if-exists"], check=True)
+            subprocess.run(["createdb", "-T", original_db_name, db_name], check=True)
             odoo.tools.config["db_name"] = db_name
             odoo.tools.config["dbfilter"] = f"^{db_name}$"
         with _shared_filestore(original_db_name, db_name):
@@ -147,7 +148,7 @@ def _worker_db_name():
     finally:
         if db_name != original_db_name:
             odoo.sql_db.close_db(db_name)
-            os.system(f"dropdb {db_name}")
+            subprocess.run(["dropdb", db_name, "--if-exists"], check=True)
             odoo.tools.config["db_name"] = original_db_name
             odoo.tools.config["dbfilter"] = f"^{original_db_name}$"
 

--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -9,6 +9,7 @@ import os
 import signal
 import threading
 from contextlib import contextmanager
+from unittest import mock
 from pathlib import Path
 from typing import Optional
 
@@ -110,6 +111,21 @@ def load_http(request):
         odoo.service.server.start(stop=True)
         signal.signal(signal.SIGINT, signal.default_int_handler)
 
+@contextmanager
+def _shared_filestore(original_db_name, db_name):
+    # This method ensure that if tests are ran in a distributed way
+    # we share the filestore between the original database and the
+    # copy of the database. This is useful to avoid copying the
+    # filestore for each worker.
+    # This is done by patching the filestore method of the odoo
+    # configuration to point to the original filestore.
+    if original_db_name == db_name:
+        yield
+        return
+    with mock.patch.object(odoo.tools.config, "filestore") as filestore:
+        fs_path = os.path.join(odoo.tools.config['data_dir'], 'filestore', original_db_name)
+        filestore.return_value = fs_path
+        yield
 
 @contextmanager
 def _worker_db_name():
@@ -125,7 +141,8 @@ def _worker_db_name():
             os.system(f"dropdb {db_name} --if-exists")
             os.system(f"createdb -T {original_db_name} {db_name}")
             odoo.tools.config["db_name"] = db_name
-        yield db_name
+        with _shared_filestore(original_db_name, db_name):
+            yield db_name
     finally:
         if db_name != original_db_name:
             odoo.sql_db.close_db(db_name)


### PR DESCRIPTION
When test are ran in a distributed way, we must ensure that each worker has access to the original filestore even if they uses a copy of the original database. This is done by patching the the filestore method of the odoo configuration to point to the original filestore and avoid to copy the original filestore for each created database.

This PR also provides a fix for tests using HTTP controllers.