### PR TITLE
Support Odoo v18.0: disable odoo test retry feature

### DIFF
--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -88,6 +88,7 @@ def pytest_cmdline_main(config):
             raise Exception(
                 "please provide a database name in the Odoo configuration file"
             )
+        disable_odoo_test_retry()
         monkey_patch_resolve_pkg_root_and_module_name()
         odoo.service.server.start(preload=[], stop=True)
         # odoo.service.server.start() modifies the SIGINT signal by its own
@@ -199,6 +200,20 @@ def monkey_patch_resolve_pkg_root_and_module_name():
 
 
     _pytest.pathlib.resolve_pkg_root_and_module_name= resolve_pkg_root_and_module_name
+
+
+def disable_odoo_test_retry():
+    """Odoo BaseCase.run method overload TestCase.run and manage
+    a retry mechanism that breaks using pytest launcher.
+    Using `pytest-rerunfailures` we can use `--reruns` parameters
+    if needs equivalent feature, so we remove such overload here.
+    """
+    try:
+        from odoo.tests import BaseCase
+        if hasattr(BaseCase, "run"):
+            del BaseCase.run
+    except ImportError:
+        pass
 
 
 def _find_manifest_path(collection_path: Path) -> Path:

--- a/tests/mock/odoo/odoo/tests/__init__.py
+++ b/tests/mock/odoo/odoo/tests/__init__.py
@@ -1,2 +1,8 @@
 from unittest.mock import MagicMock
 common = MagicMock()
+
+
+class BaseCase:
+
+    def run(*args, **kwargs):
+        super().run(*args, **kwargs)

--- a/tests/test_pytest_odoo.py
+++ b/tests/test_pytest_odoo.py
@@ -7,6 +7,7 @@ from _pytest import pathlib as pytest_pathlib
 from pytest_odoo import (
     _find_manifest_path,
     monkey_patch_resolve_pkg_root_and_module_name,
+    disable_odoo_test_retry,
 )
 
 
@@ -84,3 +85,47 @@ class TestPytestOdoo(TestCase):
                 module_name,
                 "odoo.addons.my_module.tests.test_module"
             )
+
+    def test_disable_odoo_test_retry(self):
+        from odoo.tests import BaseCase
+
+        original_basecase_run= BaseCase.run
+
+        def restore_basecase_run():
+            BaseCase.run = original_basecase_run
+        
+        self.addCleanup(restore_basecase_run)
+
+        disable_odoo_test_retry()
+        self.assertFalse(hasattr(BaseCase, "run"))
+
+
+    def test_disable_odoo_test_retry_ignore_run_doesnt_exists(self):
+        from odoo.tests import BaseCase
+
+        original_basecase_run= BaseCase.run
+
+        def restore_basecase_run():
+            BaseCase.run = original_basecase_run
+        
+        self.addCleanup(restore_basecase_run)
+        
+        del BaseCase.run
+        
+        disable_odoo_test_retry()
+        self.assertFalse(hasattr(BaseCase, "run"))
+
+
+
+    def test_import_error(self):
+        from odoo import tests 
+        
+        original_BaseCase = tests.BaseCase
+
+        def restore_basecase():
+            tests.BaseCase = original_BaseCase
+        
+        self.addCleanup(restore_basecase)
+        
+        disable_odoo_test_retry()
+        


### PR DESCRIPTION
End of #79 

Odoo reject the support to pytest-odoo: https://github.com/odoo/odoo/pull/184409.

Si here we removes the retry feature implemented by odoo. Users that want to retry failures test can use  option from [pytest-rerunfailures](https://pypi.org/project/pytest-rerunfailures/) pytest plugin package.