### PR TITLE
add flag to disable environment variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,8 @@ Alternatively, you can use environment variables, like the Odoo Docker image:
 
 These only work in addition to ``--odoo-database``.
 
+In case these environment variables conflict with your setup, you may use ``--odoo-ignore-env-db-param``.
+
 You can use the ``ODOO_RC`` environment variable using an odoo configuration file, containing at least the ``database`` option with the name of the database to test::
 
    export ODOO_RC=/path/to/odoo/config.cfg

--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -44,7 +44,10 @@ def pytest_addoption(parser):
                      default=[],
                      help="Extra options to pass to odoo "
                      "(e.g. --odoo-extra workers=0 --odoo-extra db-filter=odoo_test)")
-
+    parser.addoption("--odoo-ignore-env-db-param",
+                     action="store_true",
+                     help="Disable using environment variables for DB parameters "
+                     "(HOST, PORT, USER, PASSWORD)")
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_cmdline_main(config):
@@ -76,9 +79,10 @@ def pytest_cmdline_main(config):
 
         # Check the environment variables supported by the Odoo Docker image
         # ref: https://hub.docker.com/_/odoo
-        for arg in ['HOST', 'PORT', 'USER', 'PASSWORD']:
-            if os.environ.get(arg):
-                options.append('--db_%s=%s' % (arg.lower(), os.environ.get(arg)))
+        if not config.getoption("--odoo-ignore-env-db-param"):
+            for arg in ['HOST', 'PORT', 'USER', 'PASSWORD']:
+                if os.environ.get(arg):
+                    options.append('--db_%s=%s' % (arg.lower(), os.environ.get(arg)))
 
         odoo.tools.config.parse_config(options)
 


### PR DESCRIPTION
I added a flag ``--odoo-disable-docker-env`` that allows disabling the ``HOST`` ``PORT`` ``USER`` and ``PASSWORD`` environment variables added in #57 as they may conflict with environment variables in some development setups (mainly ``USER`` is extremely common to be set)

If there are any improvements needed for this to get merged, please do tell - I'd love to see this issue fixed as currently it makes pytest-odoo unusable without patches for me with my setup...


closes: #81 
