### PR TITLE
Fix support to subTest context manager for odoo >= 16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
             os: ubuntu-latest
           - PYTHON_VERSION: "3.12"
             os: ubuntu-latest
+          - PYTHON_VERSION: "3.13"
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/README.rst
+++ b/README.rst
@@ -53,3 +53,5 @@ You can use the ``ODOO_RC`` environment variable using an odoo configuration fil
 
 The plugin is also compatible with distributed run provided by the `pytest-xdist <https://pypi.org/project/pytest-xdist/>`_ library. When tests are distributed, a copy of the database is created for each worker at the start of the test session.
 This is useful to avoid concurrent access to the same database, which can lead to deadlocks. The provided database is therefore used only as template. At the end of the tests, all the created databases are dropped.
+
+The plugin is also compatible with `pytest-subtests <https://pypi.org/project/pytest-subtests/>`_ library. When test use the `subTest` context manager you'll get a nice output for each sub-tests failing.

--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -10,7 +10,7 @@ import signal
 import subprocess
 import threading
 from contextlib import contextmanager
-from unittest import mock, TestCase
+from unittest import mock, TestCase as UnitTestTestCase
 from pathlib import Path
 from typing import Optional
 
@@ -220,18 +220,19 @@ def disable_odoo_test_retry():
         pass
 
 def support_subtest():
-    """Odoo from version 16.0 overwrite TestCase.SubTest context manager
+    """Odoo from version 16.0 re-define its own TestCase.subTest context manager
 
-    This overwrite assume the usage of OdooTestResult which we are not
-    using with pytest-odoo. So this restaure unitest SubTest Context manager
+    Odoo assume the usage of OdooTestResult which is not our case
+    using with pytest-odoo. So this fallback to the unitest.TestCase.subTest
+    Context manager
     """
     try:
-        from odoo.tests import  BaseCase
-        BaseCase.subTest = TestCase.subTest
+        from odoo.tests.case import TestCase
+        TestCase.subTest = UnitTestTestCase.subTest
 
         from odoo.tests.case import _Outcome
         _Outcome.result_supports_subtests = False
-    except (ImportError, AttributeError):
+    except ImportError:
         # Odoo <= 15.0
         pass
 

--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -10,7 +10,7 @@ import signal
 import subprocess
 import threading
 from contextlib import contextmanager
-from unittest import mock
+from unittest import mock, TestCase
 from pathlib import Path
 from typing import Optional
 
@@ -89,6 +89,7 @@ def pytest_cmdline_main(config):
                 "please provide a database name in the Odoo configuration file"
             )
         disable_odoo_test_retry()
+        support_subtest()
         monkey_patch_resolve_pkg_root_and_module_name()
         odoo.service.server.start(preload=[], stop=True)
         # odoo.service.server.start() modifies the SIGINT signal by its own
@@ -214,6 +215,22 @@ def disable_odoo_test_retry():
     try:
         from odoo.tests import BaseCase
         del BaseCase.run
+    except (ImportError, AttributeError):
+        # Odoo <= 15.0
+        pass
+
+def support_subtest():
+    """Odoo from version 16.0 overwrite TestCase.SubTest context manager
+
+    This overwrite assume the usage of OdooTestResult which we are not
+    using with pytest-odoo. So this restaure unitest SubTest Context manager
+    """
+    try:
+        from odoo.tests import  BaseCase
+        BaseCase.subTest = TestCase.subTest
+
+        from odoo.tests.case import _Outcome
+        _Outcome.result_supports_subtests = False
     except (ImportError, AttributeError):
         # Odoo <= 15.0
         pass

--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -10,9 +10,10 @@ import signal
 import subprocess
 import threading
 from contextlib import contextmanager
-from unittest import mock, TestCase as UnitTestTestCase
 from pathlib import Path
 from typing import Optional
+from unittest import TestCase as UnitTestTestCase
+from unittest import mock
 
 import _pytest
 import _pytest.python
@@ -88,8 +89,8 @@ def pytest_cmdline_main(config):
             raise Exception(
                 "please provide a database name in the Odoo configuration file"
             )
-        disable_odoo_test_retry()
         support_subtest()
+        disable_odoo_test_retry()
         monkey_patch_resolve_pkg_root_and_module_name()
         odoo.service.server.start(preload=[], stop=True)
         # odoo.service.server.start() modifies the SIGINT signal by its own
@@ -108,7 +109,6 @@ def pytest_cmdline_main(config):
             yield
     else:
         yield
-
 
 @pytest.fixture(scope="module", autouse=True)
 def load_http(request):
@@ -156,7 +156,7 @@ def _worker_db_name():
             odoo.tools.config["db_name"] = original_db_name
             odoo.tools.config["dbfilter"] = f"^{original_db_name}$"
 
-    
+
 @pytest.fixture(scope='session', autouse=True)
 def load_registry():
     # Initialize the registry before running tests.
@@ -206,6 +206,22 @@ def monkey_patch_resolve_pkg_root_and_module_name():
     _pytest.pathlib.resolve_pkg_root_and_module_name= resolve_pkg_root_and_module_name
 
 
+def support_subtest():
+    """Odoo from version 16.0 re-define its own TestCase.subTest context manager
+
+    Odoo assume the usage of OdooTestResult which is not our case
+    using with pytest-odoo. So this fallback to the unitest.TestCase.subTest
+    Context manager
+    """
+    try:
+        from odoo.tests.case import TestCase
+        TestCase.subTest = UnitTestTestCase.subTest
+        TestCase.run = UnitTestTestCase.run
+    except ImportError:
+        # Odoo <= 15.0
+        pass
+
+
 def disable_odoo_test_retry():
     """Odoo BaseCase.run method overload TestCase.run and manage
     a retry mechanism that breaks using pytest launcher.
@@ -219,22 +235,6 @@ def disable_odoo_test_retry():
         # Odoo <= 15.0
         pass
 
-def support_subtest():
-    """Odoo from version 16.0 re-define its own TestCase.subTest context manager
-
-    Odoo assume the usage of OdooTestResult which is not our case
-    using with pytest-odoo. So this fallback to the unitest.TestCase.subTest
-    Context manager
-    """
-    try:
-        from odoo.tests.case import TestCase
-        TestCase.subTest = UnitTestTestCase.subTest
-
-        from odoo.tests.case import _Outcome
-        _Outcome.result_supports_subtests = False
-    except ImportError:
-        # Odoo <= 15.0
-        pass
 
 def _find_manifest_path(collection_path: Path) -> Path:
     """Try to locate an Odoo manifest file in the collection path."""

--- a/tests/mock/odoo/odoo/tests/__init__.py
+++ b/tests/mock/odoo/odoo/tests/__init__.py
@@ -1,8 +1,13 @@
+from . import case
+
 from unittest.mock import MagicMock
 common = MagicMock()
-from . import case
 
 class BaseCase(case.TestCase):
 
-    def run(*args, **kwargs):
+    def run(self, *args, **kwargs):
         super().run(*args, **kwargs)
+        self._call_something()
+
+    def _call_something(self):
+        pass

--- a/tests/mock/odoo/odoo/tests/__init__.py
+++ b/tests/mock/odoo/odoo/tests/__init__.py
@@ -1,8 +1,8 @@
 from unittest.mock import MagicMock
 common = MagicMock()
+from . import case
 
-
-class BaseCase:
+class BaseCase(case.TestCase):
 
     def run(*args, **kwargs):
         super().run(*args, **kwargs)

--- a/tests/mock/odoo/odoo/tests/case.py
+++ b/tests/mock/odoo/odoo/tests/case.py
@@ -1,0 +1,12 @@
+import contextlib
+
+
+class TestCase:
+    
+    @contextlib.contextmanager
+    def subTest(self, **kwargs):
+        """Simulate odoo TestCase.subTest from version 15.0"""
+
+
+class _Outcome:
+    pass

--- a/tests/mock/odoo/odoo/tests/case.py
+++ b/tests/mock/odoo/odoo/tests/case.py
@@ -2,11 +2,13 @@ import contextlib
 
 
 class TestCase:
-    
+
     @contextlib.contextmanager
     def subTest(self, **kwargs):
         """Simulate odoo TestCase.subTest from version 15.0"""
 
+    def run(self, *args, **kwargs):
+        self._call_a_method()
 
-class _Outcome:
-    pass
+    def _call_a_method(self):
+        pass

--- a/tests/test_pytest_odoo.py
+++ b/tests/test_pytest_odoo.py
@@ -127,5 +127,6 @@ class TestPytestOdoo(TestCase):
         
         self.addCleanup(restore_basecase)
         
+        del tests.BaseCase
         disable_odoo_test_retry()
         


### PR DESCRIPTION
- [x] fix to avoid hiding proper error
- [x] make it working using [pytest-subtests](https://github.com/pytest-dev/pytest-subtests)
- [x] support to python 3.13


I've test this PR against on real project using Odoo 14.0 and 17.0

To specifically test this feature :

* add some tests using the subTest context manager

```python
from odoo.tests.common import TransactionCase


class AnExampleCase(TransactionCase):
    def test_sub_test_some_fails(self):
        for i in range(3):
            with self.subTest(val=i):
                self.assertEqual(i, 0)

    def test_sub_test_pass(self):
        for i in range(3):
            with self.subTest(val=i):
                self.assertEqual(i, i)

    def test_sub_test_all_fails(self):
        for i in range(3):
            with self.subTest(val=i):
                self.assertEqual(i, 99)
```

* Install  [pytest-subtests](https://github.com/pytest-dev/pytest-subtests) plugin (`pip install pytest-subtests`)
* run your tests as usual

you should get this kind of output

```bash
uv run pytest --odoo-database fdls-test odoo/addons/pytest_add_subtest/ -vvv
2025-07-10 16:15:20,337 611162 WARNING ? py.warnings: /home/pverkest/clients/foodles/odoo/.venv/lib/python3.8/site-packages/odoo/addons/base/models/ir_actions_report.py:73: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  if LooseVersion(version) < LooseVersion('0.12.0'):
 
2025-07-10 16:15:20,338 611162 WARNING ? py.warnings: /home/pverkest/clients/foodles/odoo/.venv/lib/python3.8/site-packages/odoo/addons/base/models/ir_actions_report.py:78: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  if LooseVersion(version) >= LooseVersion('0.12.2'):
 
================================================================================================================================== test session starts ===================================================================================================================================
platform linux -- Python 3.8.20, pytest-8.3.3, pluggy-1.5.0 -- /home/pverkest/clients/foodles/odoo/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/pverkest/clients/foodles/odoo
configfile: pyproject.toml
plugins: xdist-3.6.1, github-actions-annotate-failures-0.3.0, cov-3.0.0, odoo-2.1.4.dev6+gab8c896, subtests-0.13.1
collected 3 items                                                                                                                                                                                                                                                                        

odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_all_fails (val=0) SUBFAIL
odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_all_fails (val=1) SUBFAIL
odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_all_fails (val=2) SUBFAIL
odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_all_fails PASSED
odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_pass PASSED
odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_some_fails (val=1) SUBFAIL
odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_some_fails (val=2) SUBFAIL
odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_some_fails PASSED

======================================================================================================================================== FAILURES ========================================================================================================================================
_____________________________________________________________________________________________________________________ AnExampleCase.test_sub_test_all_fails (val=0) ______________________________________________________________________________________________________________________

self = <odoo.addons.pytest_add_subtest.tests.test_pytest_addsubtest.AnExampleCase testMethod=test_sub_test_all_fails>

    def test_sub_test_all_fails(self):
        for i in range(3):
            with self.subTest(val=i):
>               self.assertEqual(i, 99)
E               AssertionError: 0 != 99

odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py:18: AssertionError
_____________________________________________________________________________________________________________________ AnExampleCase.test_sub_test_all_fails (val=1) ______________________________________________________________________________________________________________________

self = <odoo.addons.pytest_add_subtest.tests.test_pytest_addsubtest.AnExampleCase testMethod=test_sub_test_all_fails>

    def test_sub_test_all_fails(self):
        for i in range(3):
            with self.subTest(val=i):
>               self.assertEqual(i, 99)
E               AssertionError: 1 != 99

odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py:18: AssertionError
_____________________________________________________________________________________________________________________ AnExampleCase.test_sub_test_all_fails (val=2) ______________________________________________________________________________________________________________________

self = <odoo.addons.pytest_add_subtest.tests.test_pytest_addsubtest.AnExampleCase testMethod=test_sub_test_all_fails>

    def test_sub_test_all_fails(self):
        for i in range(3):
            with self.subTest(val=i):
>               self.assertEqual(i, 99)
E               AssertionError: 2 != 99

odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py:18: AssertionError
_____________________________________________________________________________________________________________________ AnExampleCase.test_sub_test_some_fails (val=1) _____________________________________________________________________________________________________________________

self = <odoo.addons.pytest_add_subtest.tests.test_pytest_addsubtest.AnExampleCase testMethod=test_sub_test_some_fails>

    def test_sub_test_some_fails(self):
        for i in range(3):
            with self.subTest(val=i):
>               self.assertEqual(i, 0)
E               AssertionError: 1 != 0

odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py:8: AssertionError
_____________________________________________________________________________________________________________________ AnExampleCase.test_sub_test_some_fails (val=2) _____________________________________________________________________________________________________________________

self = <odoo.addons.pytest_add_subtest.tests.test_pytest_addsubtest.AnExampleCase testMethod=test_sub_test_some_fails>

    def test_sub_test_some_fails(self):
        for i in range(3):
            with self.subTest(val=i):
>               self.assertEqual(i, 0)
E               AssertionError: 2 != 0

odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py:8: AssertionError
==================================================================================================================================== warnings summary ====================================================================================================================================
odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_all_fails
  /home/pverkest/clients/foodles/odoo/.venv/lib/python3.8/site-packages/requests_toolbelt/_compat.py:11: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import Mapping, MutableMapping

odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_all_fails
  /home/pverkest/clients/foodles/odoo/.venv/lib/python3.8/site-packages/zeep/loader.py:3: DeprecationWarning: defusedxml.lxml is no longer supported and will be removed in a future release.
    from defusedxml.lxml import fromstring

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================================================ short test summary info =================================================================================================================================
(val=0) SUBFAIL odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_all_fails - AssertionError: 0 != 99
(val=1) SUBFAIL odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_all_fails - AssertionError: 1 != 99
(val=2) SUBFAIL odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_all_fails - AssertionError: 2 != 99
(val=1) SUBFAIL odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_some_fails - AssertionError: 1 != 0
(val=2) SUBFAIL odoo/addons/pytest_add_subtest/tests/test_pytest_addsubtest.py::AnExampleCase::test_sub_test_some_fails - AssertionError: 2 != 0
======================================================================================================================== 5 failed, 3 passed, 2 warnings in 2.49s
```


closes #69 

