### PR TITLE
Compatibility with Odoo 18: Set odoo.modules.module.current_test

### DIFF
--- a/pytest_odoo.py
+++ b/pytest_odoo.py
@@ -96,6 +96,9 @@ def pytest_cmdline_main(config):
         # Restore the default one.
         signal.signal(signal.SIGINT, signal.default_int_handler)
 
+        if odoo.release.version_info >= (18,):
+            odoo.modules.module.current_test = True
+
         if odoo.release.version_info < (15,):
             # Refactor in Odoo 15, not needed anymore
             with odoo.api.Environment.manage():


### PR DESCRIPTION
Following new test management in Odoo 18 it replaces the usage of `config["test_enable"]`.

https://github.com/odoo/odoo/commit/4a2842ec35dc9c4eaf24754176842c6dc2a72b73