### PR TITLE
[CI]: avoid some warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,9 @@ commands_pre =
     odoo17: pip install https://github.com/OCA/OCB/archive/17.0.tar.gz
     odoo18: pip install https://github.com/OCA/OCB/archive/18.0.tar.gz
     odoo19: pip install https://github.com/OCA/OCB/archive/19.0.tar.gz
+    # Even though PyPDF is installed, PyPDF2 is pulled in when installing Odoo
+    # explicitly uninstall it to avoid warnings in logs
+    py{312,313,314}-odoo19: pip uninstall PyPDF2 -y
     !unit: odoo -d {envname} -i pytest_odoo_test_module --without-demo= --stop-after-init --addons-path={toxinidir}/tests_integration/odoo/addons
     unit: pip install tests/mock/odoo
 

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,8 @@ commands_pre =
     # Even though PyPDF is installed, PyPDF2 is pulled in when installing Odoo
     # explicitly uninstall it to avoid warnings in logs
     py{312,313,314}-odoo19: pip uninstall PyPDF2 -y
-    !unit: odoo -d {envname} -i pytest_odoo_test_module --without-demo= --stop-after-init --addons-path={toxinidir}/tests_integration/odoo/addons
+    !unit-odoo{14,15,16,17,18}: odoo -d {envname} -i pytest_odoo_test_module --without-demo= --stop-after-init --addons-path={toxinidir}/tests_integration/odoo/addons
+    !unit-odoo{19}: odoo -d {envname} -i pytest_odoo_test_module --without-demo=True --no-http --stop-after-init --addons-path={toxinidir}/tests_integration/odoo/addons
     unit: pip install tests/mock/odoo
 
 commands =


### PR DESCRIPTION
* avoid warning about http interface in version 19 using --no-http while installing odoo on Odoo 19
```log
2026-08-27 10:24:59,948 4473 WARNING ? odoo.tools.config: missing --http-interface/http_interface, using 0.0.0.0 by default, will change to 127.0.0.1 in 20.0 
``` 

* Even odoo default changed did work be explicit do not install demo data on v19 to avoid this warning
```log
2026-08-27 10:24:59,948 4473 WARNING ? odoo.tools.config: option --without-demo: since 19.0, invalid boolean value: '', assume True 
```

* Avoid some noise while lauching tests because pypdf2 is getting obselete and we already have pypdf installed
```log
2026-07-02 11:35:56,442 4493 WARNING ? py.warnings: /home/runner/work/pytest-odoo/pytest-odoo/.tox/py314-odoo19/lib/python3.14/site-packages/PyPDF2/__init__.py:21: DeprecationWarning: PyPDF2 is deprecated. Please move to the pypdf library instead.
  File "/home/runner/work/pytest-odoo/pytest-odoo/.tox/py314-odoo19/bin/odoo", line 6, in <module>
    odoo.cli.main()
  File "/home/runner/work/pytest-odoo/pytest-odoo/.tox/py314-odoo19/lib/python3.14/site-packages/odoo/cli/command.py", line 133, in main
    command().run(args)
  File "/home/runner/work/pytest-odoo/pytest-odoo/.tox/py314-odoo19/lib/python3.14/site-packages/odoo/cli/server.py", line 127, in run
    main(args)
  File "/home/runner/work/pytest-odoo/pytest-odoo/.tox/py314-odoo19/lib/python3.14/site-packages/odoo/cli/server.py", line 118, in main
    rc = server.start(preload=config['db_name'], stop=stop)
  File "/home/runner/work/pytest-odoo/pytest-odoo/.tox/py314-odoo19/lib/python3.14/site-packages/odoo/service/server.py", line 1588, in start
    load_server_wide_modules()
  File "/home/runner/work/pytest-odoo/pytest-odoo/.tox/py314-odoo19/lib/python3.14/site-packages/odoo/service/server.py", line 1493, in load_server_wide_modules
    load_openerp_module(m)
  File "/home/runner/work/pytest-odoo/pytest-odoo/.tox/py314-odoo19/lib/python3.14/site-packages/odoo/modules/module.py", line 506, in load_openerp_module
    __import__(qualname)
  File "/home/runner/work/pytest-odoo/pytest-odoo/.tox/py314-odoo19/lib/python3.14/site-packages/odoo/addons/base/__init__.py", line 4, in <module>
    from . import models
  File "/home/runner/work/pytest-odoo/pytest-odoo/.tox/py314-odoo19/lib/python3.14/site-packages/odoo/addons/base/models/__init__.py", line 12, in <module>
    from . import ir_actions_report
  File "/home/runner/work/pytest-odoo/pytest-odoo/.tox/py314-odoo19/lib/python3.14/site-packages/odoo/addons/base/models/ir_actions_report.py", line 32, in <module>
    from odoo.tools.pdf import PdfFileReader, PdfFileWriter, PdfReadError
  File "/home/runner/work/pytest-odoo/pytest-odoo/.tox/py314-odoo19/lib/python3.14/site-packages/odoo/tools/pdf/__init__.py", line 33, in <module>
    import PyPDF2.filters  # needed after PyPDF2 2.0.0 and before 2.11.0
  File "/home/runner/work/pytest-odoo/pytest-odoo/.tox/py314-odoo19/lib/python3.14/site-packages/PyPDF2/__init__.py", line 21, in <module>
    warnings.warn(
```
copy / past from https://github.com/camptocamp/pytest-odoo/actions/runs/28586745484/job/84760140535